### PR TITLE
Use adjustPageHeight instead of fixed pageHeight for verovio* functions

### DIFF
--- a/crim_intervals/main_objs.py
+++ b/crim_intervals/main_objs.py
@@ -3281,7 +3281,7 @@ class ImportedPiece:
         tk = verovio.toolkit()
         tk.loadData(fetched_mei_string)
         tk.setScale(30)
-        tk.setOptions({"pageHeight":  1500, # Height in pixels
+        tk.setOptions({"adjustPageHeight": True, # Automatic page height
                        "pageWidth":  1500    # Width in pixels
                        })
         # adding option to import filtered df of cadences
@@ -3343,7 +3343,7 @@ class ImportedPiece:
         tk = verovio.toolkit()
         tk.loadData(fetched_mei_string)
         tk.setScale(30)
-        tk.setOptions({"pageHeight":  1500, # Height in pixels
+        tk.setOptions({"adjustPageHeight": True, # Automatic page height
                        "pageWidth":  3000    # Width in pixels
                        })
 
@@ -3415,7 +3415,7 @@ class ImportedPiece:
         tk = verovio.toolkit()
         tk.loadData(fetched_mei_string)
         tk.setScale(30)
-        tk.setOptions({"pageHeight":  1500, # Height in pixels
+        tk.setOptions({"adjustPageHeight": True, # Automatic page height
                        "pageWidth":  3000    # Width in pixels
                        })
         print("Results:")
@@ -3519,7 +3519,7 @@ class ImportedPiece:
         tk = verovio.toolkit()
         tk.loadData(fetched_mei_string)
         tk.setScale(30)
-        tk.setOptions({"pageHeight":  1500, # Height in pixels
+        tk.setOptions({"adjustPageHeight": True, # Automatic page height
                        "pageWidth":  3000    # Width in pixels
                        })
 


### PR DESCRIPTION
This is my first pull request. I noticed pageHeight could be automatically adjusted, so this replaces it with adjustPageHeight to avoid unnecessary blank space and better accommodate larger scores. (Sorry for any mistakes!)